### PR TITLE
DiscordAPI

### DIFF
--- a/libs/discordAPI.lua
+++ b/libs/discordAPI.lua
@@ -1,0 +1,23 @@
+local obj = {}
+
+obj.API_TOKEN = ''
+obj.API_URL = ''
+
+function obj:init(API_TOKEN, API_URL)
+    if API_TOKEN == nil or API_URL == nil then
+        return false
+    end
+
+    self.API_TOKEN = API_TOKEN
+    self.API_URL = API_URL
+    return true
+end
+
+function obj:send(message)
+    if not http.checkURL(self.API_URL) then return false end
+    http.post(self.API_URL, "token=" .. self.API_TOKEN .. "&message=" .. message)
+    --@TODO: Check response for success message; return true / false accordingly.
+    return true
+end
+
+return obj

--- a/libs/discordAPI.lua
+++ b/libs/discordAPI.lua
@@ -1,3 +1,4 @@
+-- Uses this as API: https://github.com/ColdIV/discord-bot-api
 local obj = {}
 
 obj.API_TOKEN = ''

--- a/programs/exampleDiscordAPI.lua
+++ b/programs/exampleDiscordAPI.lua
@@ -1,0 +1,22 @@
+local args = {...}
+
+local dpm = require("dpm")
+
+local config = dpm:load("config")
+local discordAPI = dpm:load("discordAPI")
+
+config:init("exampleDiscordAPI")
+
+config:add('API_TOKEN', 'default')
+config:add('API_URL', 'default')
+
+config:handleArgs(args)
+
+if #args == 0 then
+    -- To set those, run `exampleDiscordAPI config API_TOKEN <token>` and `exampleDiscordAPI config API_URL <url>`
+    local API_TOKEN = config:get('API_TOKEN')
+    local API_URL = config:get('API_URL')
+
+    discordAPI:init(API_TOKEN, API_URL)
+    discordAPI:send("Test message (lib test)")
+end


### PR DESCRIPTION
Adds the discordAPI lib which allows you to send a message to a specific channel on a discord server via a http request from your computer or turtle inside of Minecraft.

Also adds a small example to test the lib.

Uses this API: https://github.com/ColdIV/discord-bot-api